### PR TITLE
fix wrong target type of invalidation

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -39,9 +39,6 @@ defmodule Dispatcher do
   get "/government-units/*path" do
     Proxy.forward conn, path, "http://cache/government-units/"
   end
-  get "/versions/*path" do
-    Proxy.forward conn, path, "http://cache/versions/"
-  end
   get "/agenda-items/*path" do
     Proxy.forward conn, path, "http://cache/agenda-items/"
   end

--- a/config/resources/overheid-domain.json
+++ b/config/resources/overheid-domain.json
@@ -56,12 +56,12 @@
         },
         "start-date": {
           "predicate": "prov:qualifiedGeneration",
-          "target": "version",
+          "target": "generation",
           "cardinality": "one"
         },
         "end-date": {
           "predicate": "prov:qualifiedInvalidation",
-          "target": "version",
+          "target": "invalidation",
           "cardinality": "one"
         },
         "mandates": {
@@ -158,8 +158,8 @@
       ],
       "new-resource-base": "http://themis-vlaanderen.be/id/concept-scheme/"
     },
-    "versions": {
-      "name": "version",
+    "generations": {
+      "name": "generation",
       "class": "prov:Generation",
       "attributes": {
         "time": {
@@ -173,7 +173,23 @@
           "predicate": "prov:qualifiedGeneration",
           "cardinality": "one",
           "inverse": true
-        },
+        }
+      },
+      "features": [
+        "include-uri"
+      ],
+      "new-resource-base": "http://themis-vlaanderen.be/id/generatie/"
+    },
+    "invalidations": {
+      "name": "invalidation",
+      "class": "prov:Invalidation",
+      "attributes": {
+        "time": {
+          "type": "datetime",
+          "predicate": "prov:atTime"
+        }
+      },
+      "relationships": {
         "government-body-end": {
           "target": "government-body",
           "predicate": "prov:qualifiedInvalidation",
@@ -184,7 +200,7 @@
       "features": [
         "include-uri"
       ],
-      "new-resource-base": "http://themis-vlaanderen.be/id/versie/"
+      "new-resource-base": "http://themis-vlaanderen.be/id/invalidatie/"
     }
   }
 }


### PR DESCRIPTION
See https://github.com/kanselarij-vlaanderen/app-themis/commit/24161af89e1d4c8e0e5f481abbf239565c108b51 for more detailed description of bug.  
This being defined the way it was, lead to https://github.com/kanselarij-vlaanderen/frontend-valvas/blob/8bcad14ba4cc275870d10dd4077b59101bd2488f/app/components/select-presented-by.js#L25-L36 not returning the expected results.